### PR TITLE
chore: add pre-commit hooks, CI lint/test jobs, and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# PostgreSQL
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_SERVER=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=app_db
+
+# Security
+SECRET_KEY=change-me-in-production
+
+# Redis
+REDIS_HOST=redis
+REDIS_PORT=6379

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,3 +63,57 @@ jobs:
             echo "::error::Refactor branches should not include database migrations. If schema changes are needed, use a feature/ branch."
             exit 1
           fi
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff==0.9.7
+      - run: ruff check app/
+      - run: ruff format --check app/
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: app_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt
+      - run: python -m pytest tests/ -v
+        env:
+          POSTGRES_SERVER: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: app_db
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
+          SECRET_KEY: test-secret-key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/tests/test_orphaned_todos.py
+++ b/tests/test_orphaned_todos.py
@@ -6,7 +6,7 @@ After the fix, it should PASS.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 from app.features.todo.crud import TodoCRUD
 from app.features.todo.models import Todo


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with ruff check + format hooks to catch formatting issues before commit
- Add `lint` and `test` jobs to GitHub Actions `pr-checks.yml` (Postgres + Redis service containers)
- Add `.env.example` with all required env vars so new contributors can run Docker locally
- Fix unused import (`MagicMock`) caught by ruff in `test_orphaned_todos.py`

Closes #9

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] `make lint` passes
- [ ] GitHub Actions lint job passes on this PR
- [ ] GitHub Actions test job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)