### PR TITLE
feat(auth): JWT authentication with login, register, and token refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ POSTGRES_DB=app_db
 
 # Security
 SECRET_KEY=change-me-in-production
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # Redis
 REDIS_HOST=redis

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -25,7 +25,8 @@ class Settings(BaseSettings):
 
     # Security
     SECRET_KEY: str = "change-me-in-production"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24  # 24 hours
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 
     # Redis
     REDIS_HOST: str = "redis"

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -18,19 +18,27 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     return pwd_context.verify(plain_password, hashed_password)
 
 
-def create_access_token(
-    subject: int | str, expires_delta: timedelta | None = None
-) -> str:
-    expire = datetime.now(timezone.utc) + (
-        expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+def create_access_token(subject: int | str) -> str:
+    expire = datetime.now(timezone.utc) + timedelta(
+        minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
     )
-    to_encode = {"sub": str(subject), "exp": expire}
+    to_encode = {"sub": str(subject), "exp": expire, "type": "access"}
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
 
 
-def decode_access_token(token: str) -> int | None:
+def create_refresh_token(subject: int | str) -> str:
+    expire = datetime.now(timezone.utc) + timedelta(
+        days=settings.REFRESH_TOKEN_EXPIRE_DAYS
+    )
+    to_encode = {"sub": str(subject), "exp": expire, "type": "refresh"}
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_token(token: str, expected_type: str = "access") -> int | None:
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+        if payload.get("type") != expected_type:
+            return None
         subject = payload.get("sub")
         return int(subject) if subject else None
     except (JWTError, ValueError):

--- a/app/features/auth/dependencies.py
+++ b/app/features/auth/dependencies.py
@@ -1,0 +1,29 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.common.database import get_db
+from app.core.security import decode_token
+from app.features.user import service as user_service
+from app.features.user.models import User
+
+bearer_scheme = HTTPBearer()
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    user_id = decode_token(credentials.credentials, expected_type="access")
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        )
+    user = await user_service.get_user(db, user_id=user_id)
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        )
+    return user

--- a/app/features/auth/router.py
+++ b/app/features/auth/router.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.common.database import get_db
+from app.features.user.models import User
+from app.features.user.schemas import UserResponse
+
+from . import schemas, service
+from .dependencies import get_current_user
+
+router = APIRouter()
+
+
+@router.post(
+    "/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED
+)
+async def register(body: schemas.RegisterRequest, db: AsyncSession = Depends(get_db)):
+    from app.features.user import service as user_service
+
+    existing = await user_service.get_by_email(db, email=body.email)
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email already registered",
+        )
+    return await service.register(
+        db, email=body.email, password=body.password, name=body.name
+    )
+
+
+@router.post("/login", response_model=schemas.TokenResponse)
+async def login(body: schemas.LoginRequest, db: AsyncSession = Depends(get_db)):
+    user = await service.authenticate(db, email=body.email, password=body.password)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password",
+        )
+    return service.create_tokens(user.id)
+
+
+@router.post("/refresh", response_model=schemas.RefreshResponse)
+async def refresh(body: schemas.RefreshRequest):
+    access_token = service.refresh_access_token(body.refresh_token)
+    if access_token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.get("/me", response_model=UserResponse)
+async def me(current_user: User = Depends(get_current_user)):
+    return current_user

--- a/app/features/auth/schemas.py
+++ b/app/features/auth/schemas.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel, EmailStr
+
+
+# --- Request schemas ---
+
+
+class RegisterRequest(BaseModel):
+    """POST /api/v1/auth/register"""
+
+    email: EmailStr
+    password: str
+    name: str
+
+
+class LoginRequest(BaseModel):
+    """POST /api/v1/auth/login"""
+
+    email: EmailStr
+    password: str
+
+
+class RefreshRequest(BaseModel):
+    """POST /api/v1/auth/refresh"""
+
+    refresh_token: str
+
+
+# --- Response schemas ---
+
+
+class TokenResponse(BaseModel):
+    """POST /api/v1/auth/login response"""
+
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class RefreshResponse(BaseModel):
+    """POST /api/v1/auth/refresh response"""
+
+    access_token: str
+    token_type: str = "bearer"

--- a/app/features/auth/service.py
+++ b/app/features/auth/service.py
@@ -1,0 +1,41 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    verify_password,
+)
+from app.features.user import service as user_service
+from app.features.user.models import User
+from app.features.user.schemas import UserCreate
+
+
+async def register(db: AsyncSession, email: str, password: str, name: str) -> User:
+    return await user_service.create_user(
+        db, user_in=UserCreate(email=email, password=password, name=name)
+    )
+
+
+async def authenticate(db: AsyncSession, email: str, password: str) -> User | None:
+    user = await user_service.get_by_email(db, email=email)
+    if user is None or not user.is_active:
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+def create_tokens(user_id: int) -> dict[str, str]:
+    return {
+        "access_token": create_access_token(user_id),
+        "refresh_token": create_refresh_token(user_id),
+        "token_type": "bearer",
+    }
+
+
+def refresh_access_token(refresh_token: str) -> str | None:
+    user_id = decode_token(refresh_token, expected_type="refresh")
+    if user_id is None:
+        return None
+    return create_access_token(user_id)

--- a/app/features/todo/router.py
+++ b/app/features/todo/router.py
@@ -3,7 +3,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.common.database import get_db
 from app.common.pagination import PaginationParams
-from app.features.user import service as user_service
+from app.features.auth.dependencies import get_current_user
+from app.features.user.models import User
 
 from . import schemas, service
 
@@ -13,24 +14,26 @@ router = APIRouter()
 @router.post(
     "/", response_model=schemas.TodoResponse, status_code=status.HTTP_201_CREATED
 )
-async def create_todo(todo_in: schemas.TodoCreate, db: AsyncSession = Depends(get_db)):
-    user = await user_service.get_user(db, user_id=todo_in.user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+async def create_todo(
+    todo_in: schemas.TodoCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    todo_in = todo_in.model_copy(update={"user_id": current_user.id})
     return await service.create_todo(db, todo_in=todo_in)
 
 
 @router.get("/", response_model=schemas.TodoListResponse)
 async def list_todos(
     pagination: PaginationParams = Depends(),
-    user_id: int | None = Query(None),
     todo_status: schemas.TodoStatus | None = Query(None, alias="status"),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     status_value = todo_status.value if todo_status else None
     return await service.list_todos(
         db,
-        user_id=user_id,
+        user_id=current_user.id,
         status=status_value,
         skip=pagination.skip,
         limit=pagination.limit,
@@ -38,10 +41,16 @@ async def list_todos(
 
 
 @router.get("/{todo_id}", response_model=schemas.TodoResponse)
-async def get_todo(todo_id: int, db: AsyncSession = Depends(get_db)):
+async def get_todo(
+    todo_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
     todo = await service.get_todo(db, todo_id=todo_id)
     if not todo:
         raise HTTPException(status_code=404, detail="Todo not found")
+    if todo.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
     return todo
 
 
@@ -49,17 +58,26 @@ async def get_todo(todo_id: int, db: AsyncSession = Depends(get_db)):
 async def update_todo(
     todo_id: int,
     todo_in: schemas.TodoUpdate,
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     todo = await service.get_todo(db, todo_id=todo_id)
     if not todo:
         raise HTTPException(status_code=404, detail="Todo not found")
+    if todo.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
     return await service.update_todo(db, db_obj=todo, todo_in=todo_in)
 
 
 @router.delete("/{todo_id}", response_model=schemas.TodoResponse)
-async def delete_todo(todo_id: int, db: AsyncSession = Depends(get_db)):
+async def delete_todo(
+    todo_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
     todo = await service.get_todo(db, todo_id=todo_id)
     if not todo:
         raise HTTPException(status_code=404, detail="Todo not found")
+    if todo.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
     return await service.delete_todo(db, todo_id=todo_id)

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 
+from app.features.auth.router import router as auth_router
 from app.features.user.router import router as user_router
 from app.features.todo.router import router as todo_router
 
@@ -7,6 +8,7 @@ app = FastAPI(title="Dev Workflow Template", version="0.1.0")
 
 # --- Router registration ---
 # Convention: /api/v1/{feature_name_plural}
+app.include_router(auth_router, prefix="/api/v1/auth", tags=["auth"])
 app.include_router(user_router, prefix="/api/v1/users", tags=["users"])
 app.include_router(todo_router, prefix="/api/v1/todos", tags=["todos"])
 

--- a/docs/reference/api/auth.md
+++ b/docs/reference/api/auth.md
@@ -1,0 +1,160 @@
+# Auth API Contract
+
+Base path: `/api/v1/auth`
+
+## Endpoints
+
+### POST /api/v1/auth/register
+
+Create a new user account.
+
+**Request:**
+```json
+{
+  "email": "user@example.com",
+  "password": "securepass123",
+  "name": "Jane Doe"
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": 1,
+  "email": "user@example.com",
+  "name": "Jane Doe",
+  "is_active": true,
+  "created_at": "2026-04-06T12:00:00Z",
+  "updated_at": "2026-04-06T12:00:00Z"
+}
+```
+
+**Errors:**
+| Status | Condition |
+|---|---|
+| 409 | Email already registered |
+| 422 | Invalid email format or missing fields |
+
+---
+
+### POST /api/v1/auth/login
+
+Authenticate with email/password, receive JWT tokens.
+
+**Request:**
+```json
+{
+  "email": "user@example.com",
+  "password": "securepass123"
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIs...",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIs...",
+  "token_type": "bearer"
+}
+```
+
+**Errors:**
+| Status | Condition |
+|---|---|
+| 401 | Invalid email or password |
+
+---
+
+### POST /api/v1/auth/refresh
+
+Refresh an expired access token using a valid refresh token.
+
+**Request:**
+```json
+{
+  "refresh_token": "eyJhbGciOiJIUzI1NiIs..."
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIs...",
+  "token_type": "bearer"
+}
+```
+
+**Errors:**
+| Status | Condition |
+|---|---|
+| 401 | Invalid or expired refresh token |
+
+---
+
+### GET /api/v1/auth/me
+
+Get the currently authenticated user's profile.
+
+**Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Response (200 OK):**
+```json
+{
+  "id": 1,
+  "email": "user@example.com",
+  "name": "Jane Doe",
+  "is_active": true,
+  "created_at": "2026-04-06T12:00:00Z",
+  "updated_at": "2026-04-06T12:00:00Z"
+}
+```
+
+**Errors:**
+| Status | Condition |
+|---|---|
+| 401 | Missing or invalid token |
+
+---
+
+## Authentication Dependency
+
+Protected endpoints use `Authorization: Bearer <token>` header.
+
+```python
+current_user: User = Depends(get_current_user)
+```
+
+Returns 401 if token is missing, expired, or invalid.
+
+---
+
+## Token Details
+
+| Property | Access Token | Refresh Token |
+|---|---|---|
+| Lifetime | 30 minutes | 7 days |
+| Payload `sub` | user ID | user ID |
+| Payload `type` | `"access"` | `"refresh"` |
+
+---
+
+## Schema Summary
+
+| Schema | Used in | Fields |
+|---|---|---|
+| `RegisterRequest` | POST /register body | email, password, name |
+| `LoginRequest` | POST /login body | email, password |
+| `TokenResponse` | POST /login response | access_token, refresh_token, token_type |
+| `RefreshRequest` | POST /refresh body | refresh_token |
+| `RefreshResponse` | POST /refresh response | access_token, token_type |
+
+## Notes
+
+- Reuses existing `UserResponse` schema for registration and /me responses
+- Passwords are hashed with bcrypt before storage
+- JWT signed with HS256 using `SECRET_KEY` from environment
+- Refresh tokens use the same signing key but with `type: "refresh"` in payload
+- Inactive users (`is_active=false`) are rejected at login

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pydantic-settings==2.7.1
 pydantic[email]==2.10.6
 python-dotenv==1.1.0
 passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
 python-jose[cryptography]==3.3.0
 python-multipart==0.0.20
 redis==5.3.1

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,147 @@
+"""Tests for JWT authentication feature.
+
+Tests cover: registration, login, token refresh, /me endpoint,
+and auth dependency behavior.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from app.core.security import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    hash_password,
+    verify_password,
+)
+from app.features.auth import service as auth_service
+
+
+# --- Security utility tests ---
+
+
+class TestPasswordHashing:
+    def test_hash_and_verify(self):
+        plain = "securepass123"
+        hashed = hash_password(plain)
+        assert hashed != plain
+        assert verify_password(plain, hashed)
+
+    def test_wrong_password_fails(self):
+        hashed = hash_password("correct")
+        assert not verify_password("wrong", hashed)
+
+
+class TestTokenCreation:
+    def test_access_token_roundtrip(self):
+        token = create_access_token(42)
+        user_id = decode_token(token, expected_type="access")
+        assert user_id == 42
+
+    def test_refresh_token_roundtrip(self):
+        token = create_refresh_token(42)
+        user_id = decode_token(token, expected_type="refresh")
+        assert user_id == 42
+
+    def test_access_token_rejected_as_refresh(self):
+        token = create_access_token(42)
+        assert decode_token(token, expected_type="refresh") is None
+
+    def test_refresh_token_rejected_as_access(self):
+        token = create_refresh_token(42)
+        assert decode_token(token, expected_type="access") is None
+
+    def test_invalid_token_returns_none(self):
+        assert decode_token("garbage.token.here") is None
+
+
+# --- Auth service tests ---
+
+
+class TestAuthenticate:
+    @pytest.fixture
+    def mock_db(self):
+        return AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_authenticate_success(self, mock_db):
+        user = MagicMock()
+        user.is_active = True
+        user.hashed_password = hash_password("pass123")
+
+        with patch(
+            "app.features.auth.service.user_service.get_by_email",
+            return_value=user,
+        ):
+            result = await auth_service.authenticate(
+                mock_db, email="test@example.com", password="pass123"
+            )
+            assert result is user
+
+    @pytest.mark.asyncio
+    async def test_authenticate_wrong_password(self, mock_db):
+        user = MagicMock()
+        user.is_active = True
+        user.hashed_password = hash_password("correct")
+
+        with patch(
+            "app.features.auth.service.user_service.get_by_email",
+            return_value=user,
+        ):
+            result = await auth_service.authenticate(
+                mock_db, email="test@example.com", password="wrong"
+            )
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_authenticate_user_not_found(self, mock_db):
+        with patch(
+            "app.features.auth.service.user_service.get_by_email",
+            return_value=None,
+        ):
+            result = await auth_service.authenticate(
+                mock_db, email="nobody@example.com", password="pass"
+            )
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_authenticate_inactive_user(self, mock_db):
+        user = MagicMock()
+        user.is_active = False
+
+        with patch(
+            "app.features.auth.service.user_service.get_by_email",
+            return_value=user,
+        ):
+            result = await auth_service.authenticate(
+                mock_db, email="test@example.com", password="pass"
+            )
+            assert result is None
+
+
+class TestCreateTokens:
+    def test_returns_access_and_refresh(self):
+        tokens = auth_service.create_tokens(1)
+        assert "access_token" in tokens
+        assert "refresh_token" in tokens
+        assert tokens["token_type"] == "bearer"
+
+    def test_tokens_are_valid(self):
+        tokens = auth_service.create_tokens(99)
+        assert decode_token(tokens["access_token"], expected_type="access") == 99
+        assert decode_token(tokens["refresh_token"], expected_type="refresh") == 99
+
+
+class TestRefreshAccessToken:
+    def test_valid_refresh_returns_new_access(self):
+        refresh = create_refresh_token(5)
+        new_access = auth_service.refresh_access_token(refresh)
+        assert new_access is not None
+        assert decode_token(new_access, expected_type="access") == 5
+
+    def test_access_token_rejected_for_refresh(self):
+        access = create_access_token(5)
+        assert auth_service.refresh_access_token(access) is None
+
+    def test_invalid_token_returns_none(self):
+        assert auth_service.refresh_access_token("bad.token") is None


### PR DESCRIPTION
## Summary
- Add JWT authentication feature: register, login, token refresh, and `/me` endpoints
- Protect all todo endpoints with `get_current_user` dependency (owner-only access with 403 on unauthorized)
- Update security module with refresh token support using `type` claim to distinguish access vs refresh tokens
- API contract documented at `docs/reference/api/auth.md`

Closes #11

## Changes
| File | What |
|---|---|
| `docs/reference/api/auth.md` | API contract (doc-first) |
| `app/features/auth/` | New feature module (schemas, service, router, dependencies) |
| `app/core/security.py` | Added `create_refresh_token`, `decode_token` with type claim |
| `app/core/config.py` | Added `REFRESH_TOKEN_EXPIRE_DAYS`, reduced access token to 30min |
| `app/features/todo/router.py` | All endpoints now require auth, scoped to owner |
| `app/main.py` | Register auth router at `/api/v1/auth` |
| `tests/test_auth.py` | 16 tests covering security utils + auth service |

## Test plan
- [x] All 18 tests pass (`pytest tests/ -v`)
- [x] Ruff lint + format pass
- [x] Pre-commit hooks pass
- [ ] CI lint job passes
- [ ] CI test job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)