### PR TITLE
feat(rate-limit): add Redis-backed API rate limiting

### DIFF
--- a/app/common/rate_limit.py
+++ b/app/common/rate_limit.py
@@ -1,0 +1,83 @@
+"""Redis-backed rate limiting dependency for FastAPI.
+
+Uses a sliding window counter (INCR + EXPIRE) keyed by identifier and
+endpoint group. The identifier is the authenticated user's ID when
+available, otherwise the client IP address.
+"""
+
+from collections.abc import Callable
+
+from fastapi import Depends, HTTPException, Request, status
+from redis.asyncio import Redis
+
+from app.core.config import settings
+
+_redis: Redis | None = None
+
+
+async def get_redis() -> Redis:
+    """Return a shared async Redis client, creating it on first call."""
+    global _redis  # noqa: PLW0603
+    if _redis is None:
+        _redis = Redis(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            decode_responses=True,
+        )
+    return _redis
+
+
+def _get_identifier(request: Request) -> str:
+    """Extract rate-limit identifier from the request.
+
+    Uses the authenticated user ID from ``request.state.user_id`` when
+    present (set by auth dependencies), otherwise falls back to the
+    client IP address.
+    """
+    user_id = getattr(request.state, "user_id", None)
+    if user_id is not None:
+        return f"user:{user_id}"
+    return f"ip:{request.client.host}" if request.client else "ip:unknown"
+
+
+def rate_limit(
+    max_requests: int = 60,
+    window_seconds: int = 60,
+) -> Callable:
+    """Dependency factory that enforces per-caller rate limits.
+
+    Parameters
+    ----------
+    max_requests:
+        Maximum number of requests allowed within *window_seconds*.
+    window_seconds:
+        Length of the sliding window in seconds.
+
+    Returns
+    -------
+    An async FastAPI dependency function.
+    """
+
+    async def _rate_limit_dependency(
+        request: Request,
+        redis: Redis = Depends(get_redis),
+    ) -> None:
+        identifier = _get_identifier(request)
+        # Derive a stable endpoint-group name from the route path
+        endpoint = request.scope.get("path", "unknown")
+        key = f"rate_limit:{identifier}:{endpoint}"
+
+        current = await redis.incr(key)
+        if current == 1:
+            await redis.expire(key, window_seconds)
+
+        if current > max_requests:
+            ttl = await redis.ttl(key)
+            retry_after = max(ttl, 1)
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=f"Rate limit exceeded. Try again in {retry_after} seconds.",
+                headers={"Retry-After": str(retry_after)},
+            )
+
+    return _rate_limit_dependency

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -32,6 +32,10 @@ class Settings(BaseSettings):
     REDIS_HOST: str = "redis"
     REDIS_PORT: int = 6379
 
+    # Rate limiting
+    RATE_LIMIT_PER_MINUTE: int = 60
+    RATE_LIMIT_AUTH_PER_MINUTE: int = 10
+
     # App
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"

--- a/app/features/auth/router.py
+++ b/app/features/auth/router.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.common.database import get_db
+from app.common.rate_limit import rate_limit
+from app.core.config import settings
 from app.features.user.models import User
 from app.features.user.schemas import UserResponse
 
@@ -10,9 +12,16 @@ from .dependencies import get_current_user
 
 router = APIRouter()
 
+_auth_rate_limit = rate_limit(
+    max_requests=settings.RATE_LIMIT_AUTH_PER_MINUTE, window_seconds=60
+)
+
 
 @router.post(
-    "/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED
+    "/register",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_auth_rate_limit)],
 )
 async def register(body: schemas.RegisterRequest, db: AsyncSession = Depends(get_db)):
     from app.features.user import service as user_service
@@ -28,7 +37,11 @@ async def register(body: schemas.RegisterRequest, db: AsyncSession = Depends(get
     )
 
 
-@router.post("/login", response_model=schemas.TokenResponse)
+@router.post(
+    "/login",
+    response_model=schemas.TokenResponse,
+    dependencies=[Depends(_auth_rate_limit)],
+)
 async def login(body: schemas.LoginRequest, db: AsyncSession = Depends(get_db)):
     user = await service.authenticate(db, email=body.email, password=body.password)
     if user is None:
@@ -39,7 +52,11 @@ async def login(body: schemas.LoginRequest, db: AsyncSession = Depends(get_db)):
     return service.create_tokens(user.id)
 
 
-@router.post("/refresh", response_model=schemas.RefreshResponse)
+@router.post(
+    "/refresh",
+    response_model=schemas.RefreshResponse,
+    dependencies=[Depends(_auth_rate_limit)],
+)
 async def refresh(body: schemas.RefreshRequest):
     access_token = service.refresh_access_token(body.refresh_token)
     if access_token is None:

--- a/app/features/todo/router.py
+++ b/app/features/todo/router.py
@@ -3,12 +3,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.common.database import get_db
 from app.common.pagination import PaginationParams
+from app.common.rate_limit import rate_limit
+from app.core.config import settings
 from app.features.auth.dependencies import get_current_user
 from app.features.user.models import User
 
 from . import schemas, service
 
-router = APIRouter()
+_todo_rate_limit = rate_limit(
+    max_requests=settings.RATE_LIMIT_PER_MINUTE, window_seconds=60
+)
+
+router = APIRouter(dependencies=[Depends(_todo_rate_limit)])
 
 
 @router.post(

--- a/docs/reference/api/rate-limiting.md
+++ b/docs/reference/api/rate-limiting.md
@@ -1,0 +1,61 @@
+# Rate Limiting API Reference
+
+## Overview
+
+Redis-backed rate limiting applied as a FastAPI dependency on route handlers.
+Uses a sliding window counter (INCR + EXPIRE) per identifier per endpoint group.
+
+## Behavior
+
+| Endpoint group | Max requests | Window | Identifier |
+|---|---|---|---|
+| Auth (`/api/v1/auth/*`) | 10 per minute | 60 seconds | IP address |
+| Todos (`/api/v1/todos/*`) | 60 per minute | 60 seconds | User ID (authenticated) |
+
+### Key pattern
+
+```
+rate_limit:{identifier}:{endpoint_group}
+```
+
+- **Authenticated requests**: `identifier` = user ID (from JWT)
+- **Unauthenticated requests**: `identifier` = client IP address
+
+### Rate limit exceeded response
+
+**Status**: `429 Too Many Requests`
+
+```json
+{
+  "detail": "Rate limit exceeded. Try again in {seconds} seconds."
+}
+```
+
+**Headers**:
+
+| Header | Description |
+|---|---|
+| `Retry-After` | Seconds until the rate limit window resets |
+
+## Configuration
+
+| Setting | Default | Description |
+|---|---|---|
+| `RATE_LIMIT_PER_MINUTE` | 60 | Default rate limit for authenticated endpoints |
+| `RATE_LIMIT_AUTH_PER_MINUTE` | 10 | Stricter rate limit for auth endpoints (login, register) |
+| `REDIS_HOST` | `redis` | Redis server hostname |
+| `REDIS_PORT` | `6379` | Redis server port |
+
+## Implementation
+
+The rate limiter is implemented as a dependency factory (`rate_limit()`) in
+`app/common/rate_limit.py`. It returns an async callable suitable for use
+with `Depends()` in FastAPI route decorators.
+
+```python
+from app.common.rate_limit import rate_limit
+
+@router.post("/login", dependencies=[Depends(rate_limit(max_requests=10, window_seconds=60))])
+async def login(...):
+    ...
+```

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,148 @@
+"""Tests for Redis-backed rate limiting dependency.
+
+Tests cover: key generation, rate limit enforcement, 429 response,
+and authenticated vs unauthenticated identifier selection.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import HTTPException
+
+from app.common.rate_limit import _get_identifier, rate_limit
+
+
+class TestGetIdentifier:
+    """Test identifier extraction from request objects."""
+
+    def _make_request(self, *, user_id=None, client_host="127.0.0.1"):
+        request = MagicMock()
+        request.state = MagicMock()
+        if user_id is not None:
+            request.state.user_id = user_id
+        else:
+            # Simulate missing attribute
+            del request.state.user_id
+        request.client = MagicMock()
+        request.client.host = client_host
+        return request
+
+    def test_authenticated_user_returns_user_id(self):
+        request = self._make_request(user_id=42)
+        assert _get_identifier(request) == "user:42"
+
+    def test_unauthenticated_returns_ip(self):
+        request = self._make_request(client_host="10.0.0.1")
+        assert _get_identifier(request) == "ip:10.0.0.1"
+
+    def test_no_client_returns_unknown(self):
+        request = MagicMock()
+        request.state = MagicMock()
+        del request.state.user_id
+        request.client = None
+        assert _get_identifier(request) == "ip:unknown"
+
+
+class TestRateLimitDependency:
+    """Test the rate_limit dependency factory."""
+
+    @pytest.fixture
+    def mock_redis(self):
+        redis = AsyncMock()
+        redis.incr = AsyncMock(return_value=1)
+        redis.expire = AsyncMock()
+        redis.ttl = AsyncMock(return_value=45)
+        return redis
+
+    @pytest.fixture
+    def mock_request(self):
+        request = MagicMock()
+        request.state = MagicMock()
+        del request.state.user_id
+        request.client = MagicMock()
+        request.client.host = "192.168.1.1"
+        request.scope = {"path": "/api/v1/auth/login"}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_allows_request_under_limit(self, mock_redis, mock_request):
+        dep = rate_limit(max_requests=10, window_seconds=60)
+        mock_redis.incr.return_value = 5
+        # Should not raise
+        await dep(request=mock_request, redis=mock_redis)
+        mock_redis.incr.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sets_expire_on_first_request(self, mock_redis, mock_request):
+        dep = rate_limit(max_requests=10, window_seconds=60)
+        mock_redis.incr.return_value = 1
+        await dep(request=mock_request, redis=mock_redis)
+        mock_redis.expire.assert_called_once()
+        # Verify the TTL passed to expire
+        args = mock_redis.expire.call_args
+        assert args[0][1] == 60
+
+    @pytest.mark.asyncio
+    async def test_does_not_set_expire_on_subsequent_requests(
+        self, mock_redis, mock_request
+    ):
+        dep = rate_limit(max_requests=10, window_seconds=60)
+        mock_redis.incr.return_value = 5
+        await dep(request=mock_request, redis=mock_redis)
+        mock_redis.expire.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_raises_429_when_limit_exceeded(self, mock_redis, mock_request):
+        dep = rate_limit(max_requests=10, window_seconds=60)
+        mock_redis.incr.return_value = 11
+        mock_redis.ttl.return_value = 30
+
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request=mock_request, redis=mock_redis)
+
+        assert exc_info.value.status_code == 429
+        assert "Rate limit exceeded" in exc_info.value.detail
+        assert exc_info.value.headers["Retry-After"] == "30"
+
+    @pytest.mark.asyncio
+    async def test_retry_after_minimum_is_one(self, mock_redis, mock_request):
+        dep = rate_limit(max_requests=5, window_seconds=60)
+        mock_redis.incr.return_value = 6
+        mock_redis.ttl.return_value = -1  # Key has no TTL (edge case)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request=mock_request, redis=mock_redis)
+
+        assert exc_info.value.headers["Retry-After"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_key_includes_identifier_and_path(self, mock_redis, mock_request):
+        dep = rate_limit(max_requests=10, window_seconds=60)
+        mock_redis.incr.return_value = 1
+        await dep(request=mock_request, redis=mock_redis)
+
+        key = mock_redis.incr.call_args[0][0]
+        assert key == "rate_limit:ip:192.168.1.1:/api/v1/auth/login"
+
+    @pytest.mark.asyncio
+    async def test_authenticated_user_key(self, mock_redis):
+        request = MagicMock()
+        request.state = MagicMock()
+        request.state.user_id = 99
+        request.client = MagicMock()
+        request.client.host = "10.0.0.1"
+        request.scope = {"path": "/api/v1/todos/"}
+
+        dep = rate_limit(max_requests=60, window_seconds=60)
+        mock_redis.incr.return_value = 1
+        await dep(request=request, redis=mock_redis)
+
+        key = mock_redis.incr.call_args[0][0]
+        assert key == "rate_limit:user:99:/api/v1/todos/"
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_limit_is_allowed(self, mock_redis, mock_request):
+        dep = rate_limit(max_requests=10, window_seconds=60)
+        mock_redis.incr.return_value = 10  # Exactly at limit, not over
+        # Should not raise
+        await dep(request=mock_request, redis=mock_redis)


### PR DESCRIPTION
## Summary

- Add Redis-backed sliding window rate limiting as a FastAPI dependency
- Auth endpoints (`/register`, `/login`, `/refresh`) limited to 10 req/min per IP
- Todo endpoints limited to 60 req/min per authenticated user
- Returns `429 Too Many Requests` with `Retry-After` header when exceeded

## Changes

- `app/core/config.py` — Added `RATE_LIMIT_PER_MINUTE` and `RATE_LIMIT_AUTH_PER_MINUTE` settings
- `app/common/rate_limit.py` — New dependency factory using Redis INCR + EXPIRE
- `app/features/auth/router.py` — Applied auth rate limit to all auth endpoints
- `app/features/todo/router.py` — Applied standard rate limit at router level
- `docs/reference/api/rate-limiting.md` — API reference documentation
- `tests/test_rate_limit.py` — 11 tests covering key generation, enforcement, and edge cases

## Test plan

- [x] All 29 tests pass (`pytest tests/ -v`)
- [x] Rate limit key correctly uses user ID for authenticated requests
- [x] Rate limit key correctly uses IP for unauthenticated requests
- [x] 429 raised with Retry-After header when limit exceeded
- [x] Exactly-at-limit requests are allowed (boundary test)
- [x] TTL set only on first request in window
- [ ] Manual test with Redis in Docker to verify end-to-end

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)