### PR TITLE
feat(rbac): add role-based access control with admin role

### DIFF
--- a/alembic/versions/1769055ab1c3_add_role_column_to_users.py
+++ b/alembic/versions/1769055ab1c3_add_role_column_to_users.py
@@ -1,0 +1,26 @@
+"""add role column to users
+
+Revision ID: 1769055ab1c3
+Revises: None
+Create Date: 2026-04-06
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "1769055ab1c3"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column("role", sa.String(20), nullable=False, server_default="user"),
+    )
+
+
+def downgrade():
+    op.drop_column("users", "role")

--- a/app/features/auth/dependencies.py
+++ b/app/features/auth/dependencies.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.common.database import get_db
 from app.core.security import decode_token
 from app.features.user import service as user_service
-from app.features.user.models import User
+from app.features.user.models import User, UserRole
 
 bearer_scheme = HTTPBearer()
 
@@ -27,3 +27,14 @@ async def get_current_user(
             detail="Invalid or expired token",
         )
     return user
+
+
+async def get_current_admin(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    if current_user.role != UserRole.admin.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return current_user

--- a/app/features/user/models.py
+++ b/app/features/user/models.py
@@ -1,8 +1,15 @@
+import enum
+
 from sqlalchemy import Boolean, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.common.database import Base
 from app.common.models import TimestampMixin
+
+
+class UserRole(str, enum.Enum):
+    admin = "admin"
+    user = "user"
 
 
 class User(TimestampMixin, Base):
@@ -12,4 +19,7 @@ class User(TimestampMixin, Base):
     email: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
     name: Mapped[str] = mapped_column(String, nullable=False)
     hashed_password: Mapped[str] = mapped_column(String, nullable=False)
+    role: Mapped[str] = mapped_column(
+        String(20), default=UserRole.user.value, nullable=False
+    )
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/app/features/user/router.py
+++ b/app/features/user/router.py
@@ -3,6 +3,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.common.database import get_db
 from app.common.pagination import PaginationParams
+from app.features.auth.dependencies import get_current_admin, get_current_user
+from app.features.user.models import User, UserRole
 
 from . import schemas, service
 
@@ -23,12 +25,17 @@ async def create_user(user_in: schemas.UserCreate, db: AsyncSession = Depends(ge
 async def list_users(
     pagination: PaginationParams = Depends(),
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_admin),
 ):
     return await service.list_users(db, skip=pagination.skip, limit=pagination.limit)
 
 
 @router.get("/{user_id}", response_model=schemas.UserResponse)
-async def get_user(user_id: int, db: AsyncSession = Depends(get_db)):
+async def get_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     user = await service.get_user(db, user_id=user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
@@ -40,7 +47,16 @@ async def update_user(
     user_id: int,
     user_in: schemas.UserUpdate,
     db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
 ):
+    # Only owner or admin can update
+    if current_user.id != user_id and current_user.role != UserRole.admin.value:
+        raise HTTPException(status_code=403, detail="Not allowed to update this user")
+
+    # Only admin can change roles
+    if user_in.role is not None and current_user.role != UserRole.admin.value:
+        raise HTTPException(status_code=403, detail="Only admins can change roles")
+
     user = await service.get_user(db, user_id=user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
@@ -52,7 +68,11 @@ async def update_user(
 
 
 @router.delete("/{user_id}", response_model=schemas.UserResponse)
-async def delete_user(user_id: int, db: AsyncSession = Depends(get_db)):
+async def delete_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_admin),
+):
     user = await service.get_user(db, user_id=user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/app/features/user/schemas.py
+++ b/app/features/user/schemas.py
@@ -19,6 +19,7 @@ class UserUpdate(BaseModel):
 
     name: str | None = None
     email: EmailStr | None = None
+    role: str | None = None
 
 
 # --- Response schemas (what the API returns) ---
@@ -30,6 +31,7 @@ class UserResponse(BaseModel):
     id: int
     email: str
     name: str
+    role: str
     is_active: bool
     created_at: datetime
     updated_at: datetime

--- a/docs/decisions/0004-role-based-access-control.md
+++ b/docs/decisions/0004-role-based-access-control.md
@@ -1,0 +1,30 @@
+# 4. Role-Based Access Control
+
+Date: 2026-04-06
+
+## Status
+
+Proposed
+
+## Context
+
+The application has JWT authentication but no authorization. All authenticated users can perform any action, including listing all users and deleting accounts. We need to restrict sensitive operations (user management, deletions) to administrators while keeping profile viewing open to all authenticated users.
+
+## Decision
+
+Add a `role` column to the `users` table with a string enum (`admin`, `user`). Default is `user`. Introduce a `get_current_admin` dependency that wraps `get_current_user` and checks the role. Protect endpoints:
+
+- `GET /api/v1/users` (list) -- admin only
+- `DELETE /api/v1/users/{id}` -- admin only
+- `PATCH /api/v1/users/{id}` -- owner or admin
+- `GET /api/v1/users/{id}` -- any authenticated user
+
+We use a simple string column rather than a separate roles/permissions table because the application currently only needs two roles. A many-to-many permission system would add complexity without current benefit.
+
+## Consequences
+
+- Admin users can manage other users; regular users cannot
+- Registration defaults to `user` role -- no self-promotion
+- Role is stored as a string column for simplicity and easy migration to a full RBAC table later
+- Existing users will receive `user` role via server_default in migration
+- API contracts change: `UserResponse` now includes `role`, `UserUpdate` accepts optional `role`

--- a/docs/reference/erd.md
+++ b/docs/reference/erd.md
@@ -9,6 +9,7 @@ erDiagram
         string email UK
         string name
         string hashed_password
+        string role
         bool is_active
         datetime created_at
         datetime updated_at
@@ -37,6 +38,7 @@ erDiagram
 | email | String | unique, not null, indexed | Login identifier |
 | name | String | not null | Display name |
 | hashed_password | String | not null | bcrypt hash, never returned in API |
+| role | String(20) | not null, default "user" | One of: admin, user |
 | is_active | Boolean | not null, default true | Soft delete flag |
 | created_at | DateTime | not null, default now() | TimestampMixin |
 | updated_at | DateTime | not null, default now(), on update now() | TimestampMixin |

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,138 @@
+"""Tests for role-based access control.
+
+Tests cover: default role assignment, admin dependency behavior,
+and endpoint protection for admin-only routes.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from fastapi import HTTPException
+
+from app.features.auth.dependencies import get_current_admin
+from app.features.user.models import UserRole
+
+
+# --- UserRole enum tests ---
+
+
+class TestUserRole:
+    def test_default_role_is_user(self):
+        assert UserRole.user.value == "user"
+
+    def test_admin_role_value(self):
+        assert UserRole.admin.value == "admin"
+
+    def test_role_is_string_enum(self):
+        assert isinstance(UserRole.admin, str)
+        assert isinstance(UserRole.user, str)
+
+
+# --- get_current_admin dependency tests ---
+
+
+class TestGetCurrentAdmin:
+    @pytest.mark.asyncio
+    async def test_admin_user_allowed(self):
+        admin_user = MagicMock()
+        admin_user.role = UserRole.admin.value
+
+        result = await get_current_admin(current_user=admin_user)
+        assert result is admin_user
+
+    @pytest.mark.asyncio
+    async def test_regular_user_rejected_with_403(self):
+        regular_user = MagicMock()
+        regular_user.role = UserRole.user.value
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_admin(current_user=regular_user)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Admin access required"
+
+
+# --- User model default role tests ---
+
+
+class TestUserModelRole:
+    def test_user_model_has_role_column(self):
+        from app.features.user.models import User
+
+        assert hasattr(User, "role")
+
+    def test_role_column_default(self):
+        from app.features.user.models import User
+
+        # Check that the column has the right default
+        role_col = User.__table__.columns["role"]
+        assert role_col.default.arg == UserRole.user.value
+        assert role_col.nullable is False
+
+
+# --- Endpoint protection tests ---
+
+
+class TestAdminEndpointProtection:
+    """Test that admin-only endpoints use the get_current_admin dependency."""
+
+    def test_list_users_requires_admin(self):
+        """Verify list_users endpoint has admin dependency."""
+        from app.features.user.router import list_users
+
+        # Check that the endpoint signature includes admin dependency
+        import inspect
+
+        sig = inspect.signature(list_users)
+        params = sig.parameters
+        assert "current_user" in params
+
+    def test_delete_user_requires_admin(self):
+        """Verify delete_user endpoint has admin dependency."""
+        from app.features.user.router import delete_user
+
+        import inspect
+
+        sig = inspect.signature(delete_user)
+        params = sig.parameters
+        assert "current_user" in params
+
+    def test_get_user_requires_auth(self):
+        """Verify get_user endpoint requires authentication."""
+        from app.features.user.router import get_user
+
+        import inspect
+
+        sig = inspect.signature(get_user)
+        params = sig.parameters
+        assert "current_user" in params
+
+    def test_update_user_requires_auth(self):
+        """Verify update_user endpoint requires authentication."""
+        from app.features.user.router import update_user
+
+        import inspect
+
+        sig = inspect.signature(update_user)
+        params = sig.parameters
+        assert "current_user" in params
+
+
+# --- Schema tests ---
+
+
+class TestUserSchemas:
+    def test_user_response_includes_role(self):
+        from app.features.user.schemas import UserResponse
+
+        fields = UserResponse.model_fields
+        assert "role" in fields
+
+    def test_user_update_accepts_role(self):
+        from app.features.user.schemas import UserUpdate
+
+        fields = UserUpdate.model_fields
+        assert "role" in fields
+        # role should be optional
+        update = UserUpdate()
+        assert update.role is None


### PR DESCRIPTION
## Summary

- Add `UserRole` enum (`admin`, `user`) and `role` column to User model with `"user"` default
- Add `get_current_admin` dependency that returns 403 for non-admin users
- Protect user management endpoints: list/delete require admin, update requires owner or admin, get requires authentication
- Include Alembic migration for adding the role column with server_default
- ADR and ERD updated per doc-first workflow

Closes #14

## Test plan

- [x] `TestUserRole` -- enum values and string type
- [x] `TestGetCurrentAdmin` -- admin allowed, regular user gets 403
- [x] `TestUserModelRole` -- column exists with correct default
- [x] `TestAdminEndpointProtection` -- all protected endpoints have auth dependency
- [x] `TestUserSchemas` -- role in response and update schemas
- [x] All 31 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)