### PR TITLE
feat(category): add categories for todos with CRUD and filtering

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,6 +11,7 @@ from app.core.config import settings
 # Import all models so Alembic can detect them
 from app.features.user.models import User  # noqa: F401
 from app.features.todo.models import Todo  # noqa: F401
+from app.features.category.models import Category, todo_categories  # noqa: F401
 
 config = context.config
 config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)

--- a/alembic/versions/003_add_categories.py
+++ b/alembic/versions/003_add_categories.py
@@ -1,0 +1,62 @@
+"""add categories and todo_categories tables
+
+Revision ID: 003
+Revises:
+Create Date: 2026-04-06
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "003"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "categories",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("color", sa.String(length=7), nullable=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_categories_user_id", "categories", ["user_id"])
+    op.create_index("ix_categories_id", "categories", ["id"])
+
+    op.create_table(
+        "todo_categories",
+        sa.Column(
+            "todo_id",
+            sa.Integer(),
+            sa.ForeignKey("todos.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "category_id",
+            sa.Integer(),
+            sa.ForeignKey("categories.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("todo_categories")
+    op.drop_index("ix_categories_user_id", table_name="categories")
+    op.drop_index("ix_categories_id", table_name="categories")
+    op.drop_table("categories")

--- a/app/features/category/crud.py
+++ b/app/features/category/crud.py
@@ -1,0 +1,32 @@
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.common.crud import GenericCRUD
+
+from .models import Category
+
+
+class CategoryCRUD(GenericCRUD[Category]):
+    async def get_by_user(
+        self, db: AsyncSession, user_id: int, *, skip: int = 0, limit: int = 20
+    ) -> list[Category]:
+        stmt = (
+            select(self.model)
+            .where(self.model.user_id == user_id)
+            .offset(skip)
+            .limit(limit)
+        )
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def count_by_user(self, db: AsyncSession, user_id: int) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(self.model)
+            .where(self.model.user_id == user_id)
+        )
+        result = await db.execute(stmt)
+        return result.scalar_one()
+
+
+category = CategoryCRUD(Category)

--- a/app/features/category/models.py
+++ b/app/features/category/models.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, ForeignKey, Integer, String, Table
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.common.database import Base
+from app.common.models import TimestampMixin
+
+# Many-to-many junction table
+todo_categories = Table(
+    "todo_categories",
+    Base.metadata,
+    Column(
+        "todo_id",
+        Integer,
+        ForeignKey("todos.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "category_id",
+        Integer,
+        ForeignKey("categories.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+)
+
+
+class Category(TimestampMixin, Base):
+    __tablename__ = "categories"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    color: Mapped[str | None] = mapped_column(String(7), nullable=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id"), nullable=False, index=True
+    )
+
+    user = relationship("User", backref="categories")
+    todos = relationship("Todo", secondary=todo_categories, back_populates="categories")

--- a/app/features/category/router.py
+++ b/app/features/category/router.py
@@ -1,0 +1,78 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.common.database import get_db
+from app.common.pagination import PaginationParams
+from app.features.auth.dependencies import get_current_user
+from app.features.user.models import User
+
+from . import schemas, service
+
+router = APIRouter()
+
+
+@router.post(
+    "/", response_model=schemas.CategoryResponse, status_code=status.HTTP_201_CREATED
+)
+async def create_category(
+    category_in: schemas.CategoryCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await service.create_category(
+        db, user_id=current_user.id, category_in=category_in
+    )
+
+
+@router.get("/", response_model=schemas.CategoryListResponse)
+async def list_categories(
+    pagination: PaginationParams = Depends(),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await service.list_categories(
+        db, user_id=current_user.id, skip=pagination.skip, limit=pagination.limit
+    )
+
+
+@router.get("/{category_id}", response_model=schemas.CategoryResponse)
+async def get_category(
+    category_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    cat = await service.get_category(db, category_id=category_id)
+    if not cat:
+        raise HTTPException(status_code=404, detail="Category not found")
+    if cat.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+    return cat
+
+
+@router.patch("/{category_id}", response_model=schemas.CategoryResponse)
+async def update_category(
+    category_id: int,
+    category_in: schemas.CategoryUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    cat = await service.get_category(db, category_id=category_id)
+    if not cat:
+        raise HTTPException(status_code=404, detail="Category not found")
+    if cat.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+    return await service.update_category(db, db_obj=cat, category_in=category_in)
+
+
+@router.delete("/{category_id}", response_model=schemas.CategoryResponse)
+async def delete_category(
+    category_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    cat = await service.get_category(db, category_id=category_id)
+    if not cat:
+        raise HTTPException(status_code=404, detail="Category not found")
+    if cat.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+    return await service.delete_category(db, category_id=category_id)

--- a/app/features/category/schemas.py
+++ b/app/features/category/schemas.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+# --- Request schemas ---
+
+
+class CategoryCreate(BaseModel):
+    """POST /api/v1/categories"""
+
+    name: str
+    color: str | None = None
+    user_id: int = 0  # Set by router from token
+
+
+class CategoryUpdate(BaseModel):
+    """PATCH /api/v1/categories/{id}"""
+
+    name: str | None = None
+    color: str | None = None
+
+
+# --- Response schemas ---
+
+
+class CategoryResponse(BaseModel):
+    """Single category response."""
+
+    id: int
+    name: str
+    color: str | None
+    user_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CategoryListResponse(BaseModel):
+    """Paginated category list."""
+
+    items: list[CategoryResponse]
+    total: int

--- a/app/features/category/service.py
+++ b/app/features/category/service.py
@@ -1,0 +1,39 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from . import crud, schemas
+from .models import Category
+
+
+async def create_category(
+    db: AsyncSession, user_id: int, category_in: schemas.CategoryCreate
+) -> Category:
+    data = category_in.model_dump()
+    data["user_id"] = user_id
+    return await crud.category.create(db, obj_in=data)
+
+
+async def list_categories(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    skip: int = 0,
+    limit: int = 20,
+) -> schemas.CategoryListResponse:
+    items = await crud.category.get_by_user(db, user_id, skip=skip, limit=limit)
+    total = await crud.category.count_by_user(db, user_id)
+    return schemas.CategoryListResponse(items=items, total=total)
+
+
+async def get_category(db: AsyncSession, category_id: int) -> Category | None:
+    return await crud.category.get(db, category_id)
+
+
+async def update_category(
+    db: AsyncSession, db_obj: Category, category_in: schemas.CategoryUpdate
+) -> Category:
+    update_data = category_in.model_dump(exclude_unset=True)
+    return await crud.category.update(db, db_obj=db_obj, obj_in=update_data)
+
+
+async def delete_category(db: AsyncSession, category_id: int) -> Category | None:
+    return await crud.category.delete(db, id=category_id)

--- a/app/features/todo/crud.py
+++ b/app/features/todo/crud.py
@@ -1,19 +1,76 @@
+from typing import Any
+
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.common.crud import GenericCRUD
+from app.features.category.models import Category, todo_categories
 from app.features.user.models import User
 
 from .models import Todo
 
 
 class TodoCRUD(GenericCRUD[Todo]):
+    async def get(self, db: AsyncSession, id: int) -> Todo | None:
+        result = await db.execute(
+            select(self.model)
+            .where(self.model.id == id)
+            .options(selectinload(self.model.categories))
+        )
+        return result.scalar_one_or_none()
+
+    async def create(self, db: AsyncSession, *, obj_in: dict[str, Any]) -> Todo:
+        category_ids = obj_in.pop("category_ids", [])
+        db_obj = self.model(**obj_in)
+        db.add(db_obj)
+        await db.flush()
+
+        if category_ids:
+            cats = await db.execute(
+                select(Category).where(Category.id.in_(category_ids))
+            )
+            db_obj.categories = list(cats.scalars().all())
+            await db.flush()
+
+        await db.refresh(db_obj)
+        # Eager load categories on the refreshed object
+        result = await db.execute(
+            select(self.model)
+            .where(self.model.id == db_obj.id)
+            .options(selectinload(self.model.categories))
+        )
+        return result.scalar_one()
+
+    async def update(
+        self, db: AsyncSession, *, db_obj: Todo, obj_in: dict[str, Any]
+    ) -> Todo:
+        category_ids = obj_in.pop("category_ids", None)
+        for field, value in obj_in.items():
+            if value is not None:
+                setattr(db_obj, field, value)
+
+        if category_ids is not None:
+            cats = await db.execute(
+                select(Category).where(Category.id.in_(category_ids))
+            )
+            db_obj.categories = list(cats.scalars().all())
+
+        await db.flush()
+        result = await db.execute(
+            select(self.model)
+            .where(self.model.id == db_obj.id)
+            .options(selectinload(self.model.categories))
+        )
+        return result.scalar_one()
+
     async def get_by_user(
         self, db: AsyncSession, user_id: int, *, skip: int = 0, limit: int = 20
     ) -> list[Todo]:
         stmt = (
             select(self.model)
             .where(self.model.user_id == user_id)
+            .options(selectinload(self.model.categories))
             .offset(skip)
             .limit(limit)
         )
@@ -26,6 +83,7 @@ class TodoCRUD(GenericCRUD[Todo]):
         stmt = (
             select(self.model)
             .where(self.model.status == status)
+            .options(selectinload(self.model.categories))
             .offset(skip)
             .limit(limit)
         )
@@ -38,11 +96,12 @@ class TodoCRUD(GenericCRUD[Todo]):
         *,
         user_id: int | None = None,
         status: str | None = None,
+        category_id: int | None = None,
         exclude_inactive_users: bool = True,
         skip: int = 0,
         limit: int = 20,
     ) -> list[Todo]:
-        stmt = select(self.model)
+        stmt = select(self.model).options(selectinload(self.model.categories))
         if exclude_inactive_users:
             stmt = stmt.join(User, self.model.user_id == User.id).where(
                 User.is_active.is_(True)
@@ -51,6 +110,10 @@ class TodoCRUD(GenericCRUD[Todo]):
             stmt = stmt.where(self.model.user_id == user_id)
         if status is not None:
             stmt = stmt.where(self.model.status == status)
+        if category_id is not None:
+            stmt = stmt.join(todo_categories).where(
+                todo_categories.c.category_id == category_id
+            )
         stmt = stmt.offset(skip).limit(limit)
         result = await db.execute(stmt)
         return list(result.scalars().all())
@@ -61,6 +124,7 @@ class TodoCRUD(GenericCRUD[Todo]):
         *,
         user_id: int | None = None,
         status: str | None = None,
+        category_id: int | None = None,
         exclude_inactive_users: bool = True,
     ) -> int:
         stmt = select(func.count()).select_from(self.model)
@@ -72,6 +136,10 @@ class TodoCRUD(GenericCRUD[Todo]):
             stmt = stmt.where(self.model.user_id == user_id)
         if status is not None:
             stmt = stmt.where(self.model.status == status)
+        if category_id is not None:
+            stmt = stmt.join(todo_categories).where(
+                todo_categories.c.category_id == category_id
+            )
         result = await db.execute(stmt)
         return result.scalar_one()
 

--- a/app/features/todo/models.py
+++ b/app/features/todo/models.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.common.database import Base
 from app.common.models import TimestampMixin
+from app.features.category.models import todo_categories
 
 
 class Todo(TimestampMixin, Base):
@@ -19,3 +20,6 @@ class Todo(TimestampMixin, Base):
     )
 
     user = relationship("User", backref="todos")
+    categories = relationship(
+        "Category", secondary=todo_categories, back_populates="todos"
+    )

--- a/app/features/todo/router.py
+++ b/app/features/todo/router.py
@@ -27,6 +27,7 @@ async def create_todo(
 async def list_todos(
     pagination: PaginationParams = Depends(),
     todo_status: schemas.TodoStatus | None = Query(None, alias="status"),
+    category_id: int | None = Query(None),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -35,6 +36,7 @@ async def list_todos(
         db,
         user_id=current_user.id,
         status=status_value,
+        category_id=category_id,
         skip=pagination.skip,
         limit=pagination.limit,
     )

--- a/app/features/todo/schemas.py
+++ b/app/features/todo/schemas.py
@@ -3,6 +3,8 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict
 
+from app.features.category.schemas import CategoryResponse
+
 
 class TodoStatus(str, Enum):
     pending = "pending"
@@ -19,6 +21,7 @@ class TodoCreate(BaseModel):
     title: str
     description: str | None = None
     user_id: int
+    category_ids: list[int] = []
 
 
 class TodoUpdate(BaseModel):
@@ -27,6 +30,7 @@ class TodoUpdate(BaseModel):
     title: str | None = None
     description: str | None = None
     status: TodoStatus | None = None
+    category_ids: list[int] | None = None
 
 
 # --- Response schemas ---
@@ -40,6 +44,7 @@ class TodoResponse(BaseModel):
     description: str | None
     status: TodoStatus
     user_id: int
+    categories: list[CategoryResponse] = []
     created_at: datetime
     updated_at: datetime
 

--- a/app/features/todo/service.py
+++ b/app/features/todo/service.py
@@ -17,13 +17,21 @@ async def list_todos(
     *,
     user_id: int | None = None,
     status: str | None = None,
+    category_id: int | None = None,
     skip: int = 0,
     limit: int = 20,
 ) -> schemas.TodoListResponse:
     items = await crud.todo.get_filtered(
-        db, user_id=user_id, status=status, skip=skip, limit=limit
+        db,
+        user_id=user_id,
+        status=status,
+        category_id=category_id,
+        skip=skip,
+        limit=limit,
     )
-    total = await crud.todo.count_filtered(db, user_id=user_id, status=status)
+    total = await crud.todo.count_filtered(
+        db, user_id=user_id, status=status, category_id=category_id
+    )
     return schemas.TodoListResponse(items=items, total=total)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from app.features.auth.router import router as auth_router
+from app.features.category.router import router as category_router
 from app.features.user.router import router as user_router
 from app.features.todo.router import router as todo_router
 
@@ -11,6 +12,7 @@ app = FastAPI(title="Dev Workflow Template", version="0.1.0")
 app.include_router(auth_router, prefix="/api/v1/auth", tags=["auth"])
 app.include_router(user_router, prefix="/api/v1/users", tags=["users"])
 app.include_router(todo_router, prefix="/api/v1/todos", tags=["todos"])
+app.include_router(category_router, prefix="/api/v1/categories", tags=["categories"])
 
 
 @app.get("/health")

--- a/docs/reference/api/categories.md
+++ b/docs/reference/api/categories.md
@@ -1,0 +1,134 @@
+# Categories API
+
+All endpoints require Bearer token authentication.
+
+## POST /api/v1/categories
+
+Create a new category for the authenticated user.
+
+### Request Body
+
+```json
+{
+  "name": "Work",
+  "color": "#ff0000"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| name | string | yes | Category name (max 100 chars) |
+| color | string | no | Hex color code (e.g. #ff0000) |
+
+### Response — 201 Created
+
+```json
+{
+  "id": 1,
+  "name": "Work",
+  "color": "#ff0000",
+  "user_id": 1,
+  "created_at": "2026-04-06T00:00:00",
+  "updated_at": "2026-04-06T00:00:00"
+}
+```
+
+## GET /api/v1/categories
+
+List categories for the authenticated user (paginated).
+
+### Query Parameters
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| skip | int | 0 | Offset for pagination |
+| limit | int | 20 | Max items per page (1-100) |
+
+### Response — 200 OK
+
+```json
+{
+  "items": [
+    {
+      "id": 1,
+      "name": "Work",
+      "color": "#ff0000",
+      "user_id": 1,
+      "created_at": "2026-04-06T00:00:00",
+      "updated_at": "2026-04-06T00:00:00"
+    }
+  ],
+  "total": 1
+}
+```
+
+## GET /api/v1/categories/{id}
+
+Get a single category. Must be the owner.
+
+### Response — 200 OK
+
+Single `CategoryResponse` object.
+
+### Errors
+
+- 404 — Category not found
+- 403 — Not the owner
+
+## PATCH /api/v1/categories/{id}
+
+Update a category. Must be the owner.
+
+### Request Body
+
+```json
+{
+  "name": "Personal",
+  "color": "#00ff00"
+}
+```
+
+All fields are optional.
+
+### Response — 200 OK
+
+Updated `CategoryResponse` object.
+
+### Errors
+
+- 404 — Category not found
+- 403 — Not the owner
+
+## DELETE /api/v1/categories/{id}
+
+Delete a category. Must be the owner. Also removes all todo-category associations.
+
+### Response — 200 OK
+
+Deleted `CategoryResponse` object.
+
+### Errors
+
+- 404 — Category not found
+- 403 — Not the owner
+
+## Todo Integration
+
+### Assigning categories to todos
+
+When creating or updating a todo, pass `category_ids` in the request body:
+
+```json
+{
+  "title": "My task",
+  "category_ids": [1, 2]
+}
+```
+
+### Filtering todos by category
+
+Use the `category_id` query parameter on `GET /api/v1/todos`:
+
+```
+GET /api/v1/todos?category_id=1
+```

--- a/docs/reference/erd.md
+++ b/docs/reference/erd.md
@@ -24,7 +24,24 @@ erDiagram
         datetime updated_at
     }
 
+    CATEGORY {
+        int id PK
+        string name
+        string color
+        int user_id FK
+        datetime created_at
+        datetime updated_at
+    }
+
+    TODO_CATEGORIES {
+        int todo_id FK
+        int category_id FK
+    }
+
     USER ||--o{ TODO : "has many"
+    USER ||--o{ CATEGORY : "has many"
+    TODO ||--o{ TODO_CATEGORIES : "tagged with"
+    CATEGORY ||--o{ TODO_CATEGORIES : "applied to"
 ```
 
 ## Tables
@@ -69,6 +86,37 @@ erDiagram
 | todos | user_id | index | Filter todos by user |
 | todos | status | index | Filter todos by status |
 | todos | id | primary key | Default |
+
+### categories
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | Integer | PK, auto-increment | |
+| name | String(100) | not null | Category name |
+| color | String(7) | nullable | Hex color code (e.g. #ff0000) |
+| user_id | Integer | FK -> users.id, not null, indexed | Owner of the category |
+| created_at | DateTime | not null, default now() | TimestampMixin |
+| updated_at | DateTime | not null, default now(), on update now() | TimestampMixin |
+
+### todo_categories (junction table)
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| todo_id | Integer | PK, FK -> todos.id (CASCADE) | |
+| category_id | Integer | PK, FK -> categories.id (CASCADE) | |
+
+### Indexes
+
+| Table | Columns | Type | Purpose |
+|---|---|---|---|
+| users | email | unique | Login lookup |
+| users | id | primary key | Default |
+| todos | user_id | index | Filter todos by user |
+| todos | status | index | Filter todos by status |
+| todos | id | primary key | Default |
+| categories | user_id | index | Filter categories by user |
+| categories | id | primary key | Default |
+| todo_categories | (todo_id, category_id) | composite PK | Unique pairing |
 
 ### Future Tables
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,235 @@
+"""Tests for category feature.
+
+Tests cover: CRUD operations, user scoping, todo-category assignment,
+and filtering todos by category.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime
+
+from app.features.category import service as category_service
+from app.features.category.schemas import (
+    CategoryCreate,
+    CategoryUpdate,
+    CategoryResponse,
+    CategoryListResponse,
+)
+from app.features.todo.schemas import TodoCreate, TodoUpdate, TodoResponse
+
+
+# --- Schema tests ---
+
+
+class TestCategorySchemas:
+    def test_category_create_with_color(self):
+        schema = CategoryCreate(name="Work", color="#ff0000")
+        assert schema.name == "Work"
+        assert schema.color == "#ff0000"
+
+    def test_category_create_without_color(self):
+        schema = CategoryCreate(name="Personal")
+        assert schema.name == "Personal"
+        assert schema.color is None
+
+    def test_category_update_partial(self):
+        schema = CategoryUpdate(name="Updated")
+        data = schema.model_dump(exclude_unset=True)
+        assert data == {"name": "Updated"}
+        assert "color" not in data
+
+    def test_category_response_from_attributes(self):
+        mock_obj = MagicMock()
+        mock_obj.id = 1
+        mock_obj.name = "Work"
+        mock_obj.color = "#ff0000"
+        mock_obj.user_id = 1
+        mock_obj.created_at = datetime(2026, 1, 1)
+        mock_obj.updated_at = datetime(2026, 1, 1)
+        resp = CategoryResponse.model_validate(mock_obj, from_attributes=True)
+        assert resp.id == 1
+        assert resp.name == "Work"
+
+    def test_category_list_response(self):
+        resp = CategoryListResponse(items=[], total=0)
+        assert resp.items == []
+        assert resp.total == 0
+
+
+class TestTodoSchemasWithCategories:
+    def test_todo_create_with_category_ids(self):
+        schema = TodoCreate(title="Test", user_id=1, category_ids=[1, 2])
+        assert schema.category_ids == [1, 2]
+
+    def test_todo_create_default_empty_categories(self):
+        schema = TodoCreate(title="Test", user_id=1)
+        assert schema.category_ids == []
+
+    def test_todo_update_with_category_ids(self):
+        schema = TodoUpdate(category_ids=[3])
+        data = schema.model_dump(exclude_unset=True)
+        assert data == {"category_ids": [3]}
+
+    def test_todo_response_includes_categories(self):
+        resp = TodoResponse(
+            id=1,
+            title="Test",
+            description=None,
+            status="pending",
+            user_id=1,
+            categories=[],
+            created_at=datetime(2026, 1, 1),
+            updated_at=datetime(2026, 1, 1),
+        )
+        assert resp.categories == []
+
+
+# --- Category service tests ---
+
+
+class TestCategoryService:
+    @pytest.fixture
+    def mock_db(self):
+        return AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_create_category(self, mock_db):
+        cat_in = CategoryCreate(name="Work", color="#ff0000")
+        mock_cat = MagicMock()
+        mock_cat.id = 1
+        mock_cat.name = "Work"
+        mock_cat.color = "#ff0000"
+        mock_cat.user_id = 5
+
+        with patch(
+            "app.features.category.service.crud.category.create",
+            return_value=mock_cat,
+        ) as mock_create:
+            result = await category_service.create_category(
+                mock_db, user_id=5, category_in=cat_in
+            )
+            assert result.name == "Work"
+            assert result.user_id == 5
+            call_args = mock_create.call_args
+            assert call_args[1]["obj_in"]["user_id"] == 5
+
+    @pytest.mark.asyncio
+    async def test_list_categories(self, mock_db):
+        item1 = MagicMock()
+        item1.id = 1
+        item1.name = "Work"
+        item1.color = "#ff0000"
+        item1.user_id = 1
+        item1.created_at = datetime(2026, 1, 1)
+        item1.updated_at = datetime(2026, 1, 1)
+
+        item2 = MagicMock()
+        item2.id = 2
+        item2.name = "Personal"
+        item2.color = None
+        item2.user_id = 1
+        item2.created_at = datetime(2026, 1, 1)
+        item2.updated_at = datetime(2026, 1, 1)
+
+        mock_items = [item1, item2]
+        with (
+            patch(
+                "app.features.category.service.crud.category.get_by_user",
+                return_value=mock_items,
+            ),
+            patch(
+                "app.features.category.service.crud.category.count_by_user",
+                return_value=2,
+            ),
+        ):
+            result = await category_service.list_categories(
+                mock_db, user_id=1, skip=0, limit=20
+            )
+            assert result.total == 2
+            assert len(result.items) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_category(self, mock_db):
+        mock_cat = MagicMock()
+        mock_cat.id = 1
+        with patch(
+            "app.features.category.service.crud.category.get",
+            return_value=mock_cat,
+        ):
+            result = await category_service.get_category(mock_db, category_id=1)
+            assert result.id == 1
+
+    @pytest.mark.asyncio
+    async def test_get_category_not_found(self, mock_db):
+        with patch(
+            "app.features.category.service.crud.category.get",
+            return_value=None,
+        ):
+            result = await category_service.get_category(mock_db, category_id=999)
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_category(self, mock_db):
+        mock_cat = MagicMock()
+        cat_in = CategoryUpdate(name="Updated")
+        mock_updated = MagicMock()
+        mock_updated.name = "Updated"
+
+        with patch(
+            "app.features.category.service.crud.category.update",
+            return_value=mock_updated,
+        ):
+            result = await category_service.update_category(
+                mock_db, db_obj=mock_cat, category_in=cat_in
+            )
+            assert result.name == "Updated"
+
+    @pytest.mark.asyncio
+    async def test_delete_category(self, mock_db):
+        mock_cat = MagicMock()
+        mock_cat.id = 1
+        with patch(
+            "app.features.category.service.crud.category.delete",
+            return_value=mock_cat,
+        ):
+            result = await category_service.delete_category(mock_db, category_id=1)
+            assert result.id == 1
+
+
+# --- User scoping tests ---
+
+
+class TestCategoryUserScoping:
+    """Categories should be scoped to the owning user."""
+
+    @pytest.fixture
+    def mock_db(self):
+        return AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_create_sets_user_id_from_param(self, mock_db):
+        cat_in = CategoryCreate(name="Test")
+        with patch(
+            "app.features.category.service.crud.category.create",
+            return_value=MagicMock(user_id=42),
+        ) as mock_create:
+            await category_service.create_category(
+                mock_db, user_id=42, category_in=cat_in
+            )
+            call_data = mock_create.call_args[1]["obj_in"]
+            assert call_data["user_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_list_filters_by_user(self, mock_db):
+        with (
+            patch(
+                "app.features.category.service.crud.category.get_by_user",
+                return_value=[],
+            ) as mock_get,
+            patch(
+                "app.features.category.service.crud.category.count_by_user",
+                return_value=0,
+            ),
+        ):
+            await category_service.list_categories(mock_db, user_id=7)
+            mock_get.assert_called_once_with(mock_db, 7, skip=0, limit=20)


### PR DESCRIPTION
## Summary
- Add `Category` model with name, color (hex), and user_id fields, plus `todo_categories` many-to-many junction table
- Implement full CRUD endpoints at `/api/v1/categories` (all user-scoped with JWT auth)
- Update Todo model, schemas, and CRUD to support category assignment (`category_ids` on create/update) and filtering (`category_id` query param on list)
- Add Alembic migration, ERD update, and API contract documentation

Closes #15

## Test plan
- [x] Category schema validation tests (create, update, response serialization)
- [x] Todo schema tests with category_ids field
- [x] Category service unit tests (create, list, get, update, delete)
- [x] User scoping tests (user_id set from token, list filters by user)
- [x] All 35 existing + new tests pass
- [ ] Manual: create category, assign to todo, filter todos by category_id
- [ ] Manual: verify 403 when accessing another user's category

🤖 Generated with [Claude Code](https://claude.com/claude-code)