### PR TITLE
chore: fix hooks, add git workflow doc, and minor improvements

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,11 +14,21 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit",
         "hooks": [
           {
             "type": "command",
             "if": "Edit(app/**)",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/doc-reminder.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Write(app/**)",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/doc-reminder.sh"
           }
         ]

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff==0.9.7
+      - run: pip install ruff
       - run: ruff check app/
       - run: ruff format --check app/
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ venv/
 
 # Claude Code
 .claude/memory/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,17 +12,20 @@ FastAPI + MVC + RIRO architecture with doc-first development workflow.
 | Database schema | @docs/reference/erd.md | When touching models or alembic |
 | API contracts | @docs/reference/api/*.md | When touching routers |
 | Docker / Makefile | @docs/reference/infrastructure.md | On demand |
+| Git workflow & PR flow | @docs/reference/git-workflow.md | When branching or creating PRs |
 | Architecture decisions | @docs/decisions/*.md | On demand |
 
-## Branch Types
+## Branching Model
 
-| Prefix | Commit prefix | SemVer |
-|---|---|---|
-| `feature/*` | `feat(scope):` | MINOR |
-| `bugfix/*` | `fix(scope):` | PATCH |
-| `hotfix/*` | `fix(scope):` | PATCH |
-| `refactor/*` | `refactor(scope):` | None |
-| `chore/*` | `chore(scope):` | None |
+**`main`** = production. **`develop`** = integration. See @docs/reference/git-workflow.md.
+
+| Prefix | Base | Commit prefix | SemVer |
+|---|---|---|---|
+| `feature/*` | `develop` | `feat(scope):` | MINOR |
+| `bugfix/*` | `develop` | `fix(scope):` | PATCH |
+| `hotfix/*` | `main` | `fix(scope):` | PATCH |
+| `refactor/*` | `develop` | `refactor(scope):` | None |
+| `chore/*` | `develop` | `chore(scope):` | None |
 
 Branch naming: `{type}/GH-{issue}-{slug}`
 

--- a/docs/reference/git-workflow.md
+++ b/docs/reference/git-workflow.md
@@ -1,0 +1,77 @@
+# Git Workflow
+
+## Branches
+
+- **`main`** — production branch. Hotfixes branch from here.
+- **`develop`** — integration branch. Features, bugfixes, refactors, and chores branch from here.
+
+## Branch Naming
+
+```
+{type}/GH-{issue}-{slug}
+```
+
+| Type | Base branch | Commit prefix | SemVer |
+|------|------------|--------------|--------|
+| `feature/` | `develop` | `feat(scope):` | MINOR |
+| `bugfix/` | `develop` | `fix(scope):` | PATCH |
+| `hotfix/` | `main` | `fix(scope):` | PATCH |
+| `refactor/` | `develop` | `refactor(scope):` | None |
+| `chore/` | `develop` | `chore(scope):` | None |
+
+Examples: `feature/GH-42-user-avatars`, `bugfix/GH-58-login-redirect`, `hotfix/INC-12-payment-crash`
+
+## PR Flow
+
+1. **Checkout** from the correct base branch:
+   ```bash
+   git checkout {base}       # main or develop
+   git pull origin {base}
+   git checkout -b {type}/GH-{issue}-{slug}
+   ```
+
+2. **Work** — commit with conventional prefix (`feat(scope):`, `fix(scope):`, etc.)
+
+3. **Before PR** — rebase onto latest base:
+   ```bash
+   git fetch origin
+   git rebase origin/{base}
+   ```
+
+4. **Resolve conflicts** if any, then push:
+   ```bash
+   git push -u origin {branch} --force-with-lease
+   ```
+
+5. **Create PR** targeting the base branch. Use the matching template from `.github/PULL_REQUEST_TEMPLATE/`.
+
+6. **Link issues** — use `Closes #N` or `Fixes #N` in the PR description.
+
+7. **Merge** — squash or merge commit.
+
+## Doc-First Rules
+
+- **feature/** — ERD + API contract BEFORE code. Docs in same PR.
+- **bugfix/** — Regression test FIRST. Minimal fix. Root cause in PR.
+- **hotfix/** — Ship first. Post-mortem ADR within 48h.
+- **refactor/** — ADR justifying why. All tests pass. No behavior change.
+- **chore/** — Tests pass. Note CVE if security.
+
+## Release Flow
+
+1. PRs merge into `develop`
+2. When ready to release: merge `develop` → `main`
+3. Tag the release on `main`
+4. Hotfixes go directly to `main`, then cherry-pick back to `develop`
+
+## Skills
+
+Each branch type has a matching skill that guides the full workflow:
+
+| Skill | What it does |
+|-------|-------------|
+| `/new-feature` | Doc-first: ERD + API contract → code → PR |
+| `/bugfix` | Diagnosis-first: regression test → minimal fix → PR |
+| `/hotfix` | Fast-track: smallest fix → PR → post-mortem later |
+| `/refactor` | Justification: ADR → restructure → prove no behavior change |
+| `/chore` | Lightweight: update → test → PR |


### PR DESCRIPTION
## Summary

Fix bugs and improve documentation found while applying this template to a real project (chartbriefs).

## Changes

- **Fix doc-reminder hook**: `Write(app/**)` was missing — new files in `app/` didn't trigger the reminder
- **Add git workflow doc**: `docs/reference/git-workflow.md` — full PR flow, branching model (main/develop), release flow, skill mapping
- **Document branching model**: CLAUDE.md now shows which branch type uses which base (`main` vs `develop`)
- **Unpin ruff**: `ruff==0.9.7` → `ruff` in CI to avoid going stale
- **Gitignore**: added `.claude/settings.local.json`

## Checklist

- [x] Tests pass (pre-commit hooks ran clean)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)